### PR TITLE
Fix undefined properties on repeated calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
+  - "10"
 branches:
   only:
     - master

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function x(o) {
 function find(prop, val) {
     if (!(prop in self.cache)) self.cache[prop] = {};
     if (self.cache[prop][val])
-        return x(self.cache[prop][val]);
+        return self.cache[prop][val];
 
     return self.cache[prop][val] = Object.keys(self.all)
         .filter(k => self.all[k][prop] == val)

--- a/t/index.js
+++ b/t/index.js
@@ -72,6 +72,10 @@ describe('Searches', () => {
         var actual = country.findByName('Denmark');
         expect(actual).to.deep.equal(DK);
     });
+    it('Find by Name repeated', function () {
+        var actual = country.findByName('Denmark');
+        expect(actual).to.deep.equal(DK);
+    });
     it('Find by capital', function () {
         var actual = country.findByCapital('Copenhagen');
         expect(actual).to.deep.equal(DK);


### PR DESCRIPTION
On a repeated call to `findByName()` and other functions, the result would have `iso2`, `iso3`, `currency_symbol`, and `currency_decimal` undefined, because the transform function is called even when [getting from the cache](https://github.com/i-rocky/country-list-js/blob/master/index.js#L69-L70) but that cache contains already transformed values (and some properties are deleted during this transformation [here](https://github.com/i-rocky/country-list-js/blob/master/index.js#L62-L63)).