### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "bugs": {
     "url": "https://github.com/i-rocky/country-list-js/issues"
   },
+  "license": "MIT",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
This is a really minor nitpick, but the MIT license isn't showing on https://www.npmjs.com/package/country-list-js - instead it shows 'none'.

I assume this is because country-list-js uses a `licenses` field but NPM only specifies `license`: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license

